### PR TITLE
Issue5:シードを入力するコンポーネントを作成する。

### DIFF
--- a/src/component/OutputRand.tsx
+++ b/src/component/OutputRand.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import XORShift from '../class/XORShift';
+import SeedInput from './SeedInput';
 
 const OutputRand = () => {
-  const [xors] = useState<XORShift>(new XORShift(10));
+  const [xors, setXors] = useState<XORShift>(new XORShift(10));
   const [printNumber, setPrintNumber] = useState<number>(-1);
   const onClick = () => {
     setPrintNumber(xors.modNext(100));
@@ -11,6 +12,7 @@ const OutputRand = () => {
     <>
       <button onClick={onClick}>next</button>
       {printNumber}
+      <SeedInput setXors={setXors} />
     </>
   );
 };

--- a/src/component/SeedInput.tsx
+++ b/src/component/SeedInput.tsx
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import { useForm, SubmitHandler } from 'react-hook-form';
+import { Button, TextField } from '@mui/material';
+
+import registerMui from '../utils/registerMui';
+import XORShift from '../class/XORShift';
+
+type SeedInputType = {
+  seed: number;
+};
+
+type Props = {
+  setXors: React.Dispatch<React.SetStateAction<XORShift>>;
+};
+
+const SeedInput = (props: Props) => {
+  const { setXors } = props;
+  const { register, handleSubmit } = useForm<SeedInputType>();
+  const onSubmit: SubmitHandler<SeedInputType> = (data) => {
+    console.log(data.seed);
+    setXors(new XORShift(data.seed));
+  };
+
+  return (
+    <>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <TextField type='number' {...registerMui(register('seed', { required: true }))} />
+        <Button variant='contained' type='submit' color='primary'>
+          シード値変更
+        </Button>
+      </form>
+    </>
+  );
+};
+
+export default SeedInput;

--- a/src/component/SeedInput.tsx
+++ b/src/component/SeedInput.tsx
@@ -17,7 +17,6 @@ const SeedInput = (props: Props) => {
   const { setXors } = props;
   const { register, handleSubmit } = useForm<SeedInputType>();
   const onSubmit: SubmitHandler<SeedInputType> = (data) => {
-    console.log(data.seed);
     setXors(new XORShift(data.seed));
   };
 

--- a/src/utils/registerMui.ts
+++ b/src/utils/registerMui.ts
@@ -1,0 +1,12 @@
+import { UseFormRegisterReturn } from 'react-hook-form';
+
+const registerMui = (res: UseFormRegisterReturn) => {
+  return {
+    inputRef: res.ref,
+    onChange: res.onChange,
+    onBlur: res.onBlur,
+    name: res.name,
+  };
+};
+
+export default registerMui;

--- a/src/utils/typeUtils.ts
+++ b/src/utils/typeUtils.ts
@@ -1,0 +1,55 @@
+// 引数xはK[]のプロパティを持っているオブジェクトであることを示す関数
+// 持っていることを示せるが、それはunknown型
+// 型ガード関数の中で用いると便利
+// 例：
+// const isDispContent = (content: unknown): content is DispContentType => {
+//   if (
+//     hasProperty(content, 'contentId', 'title', 'dialogFlag', 'dispContentItems')
+//   ) {
+//     if (
+//       typeof content.contentId === 'string' &&
+//       typeof content.title === 'string' &&
+//       typeof content.dialogFlag === 'boolean'
+//     ) {
+//       if (content.dispContentItems instanceof Array) {
+//         return (
+//           content.dispContentItems.length === 0 ||
+//           content.dispContentItems.every(e => typeof e === 'string')
+//         );
+//       }
+//     }
+//   }
+//   return false;
+// };
+export function hasProperty<K extends string>(x: unknown, ...name: K[]): x is { [M in K]: unknown } {
+  return x instanceof Object && name.every((prop) => prop in x);
+}
+// 非同期関数のReturnType時にPromiseの中身を抽出する。
+// 例:
+// type ContentItemsType = PromiseType<
+//   ReturnType<typeof ContentItemService.listContentItemsByContentId>
+// >;
+export type PromiseType<T extends Promise<unknown>> = T extends Promise<infer P> ? P : never;
+// Tips
+// 配列型から要素の型を取り出す方法。 indexed access operator([number]が肝)
+// type ContentItem = ContentItemArrayType[number]
+// 配列からundefinedを削除しつつ、それを型に教える方法
+// キーワード：Exclude、型ガード
+// 例：
+// array.filter((item): item is Exclude<typeof item, undefined> => item !== undefined)
+// undefine/nullを許容しない型に変換
+// type S = NonNullable<T> // Tはundefined/null許容。Sはundefined/null非許容
+// 以下,調査中含む
+// ジェネリクス型Tから、特定のプロパティ下(xxx)に存在する型を取り出す
+// コピペしてxxxを書き換えて使用する(コピペせず用いる形があるかは調査中)
+// キーワード：infer
+// 例：
+// type TT<T> = T extends { getTestItem?: infer R } ? R : never;
+// type TestItem = TT<GetTestItemQuery>;
+// これを入れ子にすることで、複数階層下の型を取り出せる（マシな方法があるかも）
+// 例：userContentItems?.items?.以下を取り出す
+// type TT3<T> = T extends { userContentItems?: infer R }
+//   ? R extends { items?: infer R2 }
+//     ? R2
+//     : never
+//   : never;


### PR DESCRIPTION
close #5 シードを入力するコンポーネントを作成し、確定後XORShiftインスタンスを再生成する。
- 入力フォームの関係で`no-misused-promises`を無効化している
  - eslintのルール。回避策を探したが今は時間がなく、また、無視できる問題とも考えたため無効化している。